### PR TITLE
Refactored nRF54L overlay files

### DIFF
--- a/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,9 +4,20 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-arduino_serial: &uart30 {};
+&uart30 {
+	status = "okay";
 
-#include "serial_overlay.dtsi"
+	w1_0: w1-zephyr-serial-0 {
+		compatible = "zephyr,w1-serial";
+		status = "okay";
+		mysensor1 {
+			compatible = "maxim,ds18b20";
+			family-code = <0x28>;
+			resolution = <12>;
+			label = "DS18B20";
+		};
+	};
+};
 
 &pinctrl {
 	uart30_default: uart30_default {
@@ -40,5 +51,9 @@ arduino_serial: &uart30 {};
     status = "okay";
     pinctrl-0 = <&i2c21_default>;
     pinctrl-names = "default";
-	#include "tmp112.dtsi"
+	mysensor2@48 {
+		compatible = "ti,tmp112";
+		reg = <0x48>;
+		label = "TMP112";
+	};
 };


### PR DESCRIPTION
Merged the nRF54L15 overlay files into one and renamed the two sensors to make it more clear that they can have arbitrary names.